### PR TITLE
Fixes to support calendar owners in event titles

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -88,15 +88,19 @@ EventMerger.prototype = {
 
 // merge timed events in week view
 
+function stripCalendarOwner(event_name) {
+    return event_name.trim().replace(/\(.*?\)$/g, '');
+}
+
 function weekTimedEventKey($event) {
-    var event_name = $event.find('dd span').text(),
+    var event_name = stripCalendarOwner($event.find('dd span').text()),
         event_time = $event.find('dt').text(),
         col = $event.parents('.tg-col-eventwrapper').attr('id');
     return event_name + event_time + col;
 }
 
 function tableEventKey($event) {
-    var event_name = $event.text(),
+    var event_name = stripCalendarOwner($event.text()),
         $td = $event.parents('td'),
         days = $td.attr("colspan") || 1,
         col = $td.position().left;


### PR DESCRIPTION
In some cases, Google will include names of the calendar in the event title. So you'll have two events with the names: `My Cool Event (Chris Streeter)`, `My Cool Event (example@gmail.com)`. These two should get merged, since they're the same event. But the code to detect the key for the event title wasn't taking that into account.