### PR TITLE
Fixing issues related to icons appearing on events that were merged

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -69,7 +69,7 @@ EventMerger.prototype = {
 
             var keep = event_set.shift();
             $(event_set).each(function () {
-                $(this).parent().css('visibility', 'hidden');
+                $(this).parent().css('display','none');
             });
 
             if (style_type == 'background-color') {

--- a/events.user.js
+++ b/events.user.js
@@ -91,7 +91,7 @@ EventMerger.prototype = {
 function cleanEventTitle(event_title) {
     return event_title.trim()
             .replace(/\(.*\)$/, '') // Remove parentheticals at end for 1:1 lab
-            .replace(/\W/g, ''); // Remove non-ascii chars
+            .replace(/[\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\xff]/g,''); // Remove non alphanumeric chars in the ascii range
 }
 
 function weekTimedEventKey($event) {


### PR DESCRIPTION
Using "display: none" instead of "visibility: hidden" fixes the issues related to icons showing up on events that are merged.
Fixes issues raised in: Issue #15, Issue #7