### PR TITLE
Fixing issues related to icons appearing on events that were merged

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -67,7 +67,7 @@ EventMerger.prototype = {
 
             var keep = event_set.shift();
             $(event_set).each(function () {
-                $(this).parent().css('visibility', 'hidden');
+                $(this).parent().css('display', 'none');
             });
 
             if (style_type == 'background-color') {


### PR DESCRIPTION
Using "display: none" instead of "visibility: hidden" fixes the issues related to icons showing up on events that are merged.
Fixes issues raised in the comments of: Issue #15, Issue #7, Issue #10