### PR TITLE
Detect when two events have the same color

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -46,7 +46,7 @@ EventMerger.prototype = {
 		var style_type = background.indexOf("rgba") == -1 ?
                         'background-color' : 'color';
 		var elementColor = $element.css(style_type);
-        var gradient = "repeating-linear-gradient( 135deg,",
+        var gradient = "repeating-linear-gradient( 45deg,",
             pos = 0;
 			
 		var uniqueColors = [];

--- a/events.user.js
+++ b/events.user.js
@@ -42,9 +42,21 @@ EventMerger.prototype = {
         });
     },
     makeStripes: function ($element, colors) {
-        var gradient = "repeating-linear-gradient( 45deg,",
+        var background = $element.css('background-color');
+		var style_type = background.indexOf("rgba") == -1 ?
+                        'background-color' : 'color';
+		var elementColor = $element.css(style_type);
+        var gradient = "repeating-linear-gradient( 135deg,",
             pos = 0;
-        $.each(colors, function (i, color) {
+			
+		var uniqueColors = [];
+		$.each(colors, function(i, el){
+			if($.inArray(el, uniqueColors) === -1) uniqueColors.push(el);
+		});
+		if (uniqueColors.length == 1) {
+			return;
+		}
+		$.each(uniqueColors, function (i, color) {
             gradient += color + " " + pos + "px,";
             pos += 10;
             gradient += color + " " + pos + "px,";


### PR DESCRIPTION
Detect when two events have the same color (since they are on the same calendar) and keep original stripes, so that the event will still have stripes and not have a solid color.

This fixes Issue #31 