### PR TITLE
Remove empty rows resulting from merges in all day events

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -71,6 +71,15 @@ EventMerger.prototype = {
             $(event_set).each(function () {
                 $(this).parent().css('visibility', 'hidden');
                 $(this).parent().find('*').css('visibility', 'hidden');
+                if ($(this).hasClass('rb-n')) {
+                    var row = $(this).parents('tr:first');
+                    var visible_entries = row.find('.rb-n').filter(function() {
+                        return $(this).css('visibility') != "hidden";
+                    });
+                    if (visible_entries.length == 0) {
+                        row.css('display', 'none');
+                    }
+                }
             });
 
             if (style_type == 'background-color') {


### PR DESCRIPTION
When removing a merged all-day event, check to see if its parent row has any visible events inside it. If it does not, hide it.

@imightbeamy