### PR TITLE
Add text shadows for better readability on striped background.

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -72,6 +72,7 @@ const mergeEventElements = (events) => {
     eventToKeep.style.visibility = "visible";
     eventToKeep.style.width = null;
     eventToKeep.style.border = "solid 1px #FFF"
+    eventToKeep.style.textShadow = "0px 0px 5px black";
 
     events.forEach(event => {
       event.style.visibility = "hidden";


### PR DESCRIPTION
As stated in #73 event description text on striped events are sometimes not readable. Adding slight text shadow makes look better.