### PR TITLE
White space fix ('x more' items still don't show)

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -145,23 +145,26 @@ const merge = (mainCalender) => {
       const index = eventKey.split('_')[0];
       const events = eventSet[1];
       if (events.length > 1) {
+        const length = events.length;
         mergeEventElements(events);
-        daysWithMergedEvents.push(index);
+        daysWithMergedEvents.push({ 'index': index, 'amount': length });
       } else {
         resetMergedEvents(events);
-        if (daysWithMergedEvents.includes(index)) {
-          moveOtherEvents(events);
+        const day = daysWithMergedEvents.find(day => day.index === index);
+        if (day) {
+          moveOtherEvents(events, day.amount);
         }
       }
     });
+  console.log(daysWithMergedEvents)
 };
 
 let otherEventsMoved = [];
 
-const moveOtherEvents = events => {
+const moveOtherEvents = (events, amount) => {
   if (!otherEventsMoved.includes(events[0])) {
     const originalTop = events[0].parentElement.style.top;
-    events[0].parentElement.style.top = `${parseInt(originalTop) - 1}em`;
+    events[0].parentElement.style.top = `${parseInt(originalTop) - (amount - 1)}em`;
     otherEventsMoved.push(events[0]);
   }
 };

--- a/events.user.js
+++ b/events.user.js
@@ -24,12 +24,12 @@ const stripesGradient = (colors, width, angle) => {
     colorCounts[color] -= 1;
     color = chroma(color).darken(colorCounts[color] / 3).css();
 
-    gradient += color + " " + pos + "px,";
+    gradient += color + ' ' + pos + 'px,';
     pos += width;
-    gradient += color + " " + pos + "px,";
+    gradient += color + ' ' + pos + 'px,';
   });
   gradient = gradient.slice(0, -1);
-  gradient += ")";
+  gradient += ')';
   return gradient;
 };
 
@@ -59,7 +59,7 @@ const mergeEventElements = (events) => {
 
   const eventToKeep = events.shift();
   events.forEach(event => {
-    event.style.visibility = "hidden";
+    event.style.visibility = 'hidden';
   });
 
 
@@ -77,25 +77,25 @@ const mergeEventElements = (events) => {
     };
 
     eventToKeep.style.backgroundImage = stripesGradient(colors, 10, 45);
-    eventToKeep.style.backgroundSize = "initial";
+    eventToKeep.style.backgroundSize = 'initial';
     eventToKeep.style.left = Math.min.apply(Math, positions.map(s => s.left)) + 'px';
     eventToKeep.style.right = Math.min.apply(Math, positions.map(s => s.right)) + 'px';
-    eventToKeep.style.visibility = "visible";
+    eventToKeep.style.visibility = 'visible';
     eventToKeep.style.width = null;
-    eventToKeep.style.border = "solid 1px #FFF";
+    eventToKeep.style.border = 'solid 1px #FFF';
 
     // Clear setting color for declined events
     eventToKeep.querySelector('[aria-hidden="true"]').style.color = null;
 
     const computedSpanStyle = window.getComputedStyle(eventToKeep.querySelector('span'));
-    if (computedSpanStyle.color == "rgb(255, 255, 255)") {
-      eventToKeep.style.textShadow = "0px 0px 2px black";
+    if (computedSpanStyle.color == 'rgb(255, 255, 255)') {
+      eventToKeep.style.textShadow = '0px 0px 2px black';
     } else {
-      eventToKeep.style.textShadow = "0px 0px 2px white";
+      eventToKeep.style.textShadow = '0px 0px 2px white';
     }
 
     events.forEach(event => {
-      event.style.visibility = "hidden";
+      event.style.visibility = 'hidden';
     });
   } else {
     const dots = eventToKeep.querySelector('[role="button"] div:first-child');
@@ -106,7 +106,7 @@ const mergeEventElements = (events) => {
     dot.style.height = '8px';
 
     events.forEach(event => {
-      event.style.visibility = "hidden";
+      event.style.visibility = 'hidden';
     });
   }
 };
@@ -116,21 +116,21 @@ const resetMergedEvents = (events) => {
     for (let k in event.originalStyle) {
       event.style[k] = event.originalStyle[k];
     }
-    event.style.visibility = "visible";
+    event.style.visibility = 'visible';
   });
 };
 
 const merge = (mainCalender) => {
   const eventSets = {};
-  const days = mainCalender.querySelectorAll("[role=\"gridcell\"]");
+  const days = mainCalender.querySelectorAll('[role="gridcell"]');
   days.forEach((day, index) => {
-    const events = Array.from(day.querySelectorAll("[data-eventid][role=\"button\"], [data-eventid] [role=\"button\"]"));
+    const events = Array.from(day.querySelectorAll('[data-eventid][role="button"], [data-eventid] [role="button"]'));
     events.forEach(event => {
       const eventTitleEls = event.querySelectorAll('[aria-hidden="true"]');
       if (!eventTitleEls.length) {
         return;
       }
-      let eventKey = Array.from(eventTitleEls).map(el => el.textContent).join('').replace(/\\s+/g, "");
+      let eventKey = Array.from(eventTitleEls).map(el => el.textContent).join('').replace(/\\s+/g, '');
       eventKey = index + '_' + eventKey + event.style.height;
       eventSets[eventKey] = eventSets[eventKey] || [];
       eventSets[eventKey].push(event);
@@ -141,8 +141,7 @@ const merge = (mainCalender) => {
 
   Object.entries(eventSets)
     .forEach(eventSet => {
-      const eventKey = eventSet[0];
-      const index = eventKey.split('_')[0];
+      const index = eventSet[0].split('_')[0];
       const events = eventSet[1];
       if (events.length > 1) {
         const length = events.length;
@@ -156,7 +155,6 @@ const merge = (mainCalender) => {
         }
       }
     });
-  console.log(daysWithMergedEvents)
 };
 
 let otherEventsMoved = [];
@@ -172,7 +170,7 @@ const moveOtherEvents = (events, amount) => {
 const init = (mutationsList) => {
   mutationsList && mutationsList
     .map(mutation => mutation.addedNodes[0] || mutation.target)
-    .filter(node => node.matches && node.matches("[role=\"main\"], [role=\"dialog\"], [role=\"grid\"]"))
+    .filter(node => node.matches && node.matches('[role="main"], [role="dialog"], [role="grid"]'))
     .map(merge);
 };
 


### PR DESCRIPTION
Fixes issue #10 and #80. 
Events that are not merged move up with (amount of merged evens - 1)em. 

Events under 'x more' don't show when non-merged events are moved up. 
When zoomed out (with css zoom property or in browser) 'x more' collapses. Height of div [role="presentation"] under div [role="row"] increases so more events fit. Maybe possible to create array of events and override repaint when zoomed back in.
![example](https://user-images.githubusercontent.com/6934044/92407580-43bc4d80-f13b-11ea-8ed7-a8bbfbaaea11.png)
