### PR TITLE
Update extension to manifest v3 and v3-compatible APIs

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,11 +1,11 @@
 const getSetting = () => new Promise(res => chrome.storage.local.get('disabled', (s) => res(s.disabled)));
-const setIcon = (disabled) => chrome.browserAction.setIcon({
+const setIcon = (disabled) => chrome.action.setIcon({
   path: disabled ? "icon-disabled.png" : "icon.png"
 });
 
 getSetting().then(setIcon);
 
-chrome.browserAction.onClicked.addListener(function(tab) {
+chrome.action.onClicked.addListener(function(tab) {
   getSetting().then(disabled => {
     const toggled = !disabled;
     chrome.storage.local.set({ 'disabled': toggled });

--- a/manifest.json
+++ b/manifest.json
@@ -1,31 +1,37 @@
 {
+  "manifest_version": 3,
   "name": "__MSG_appName__",
   "description": "__MSG_appDesc__",
   "default_locale": "en",
   "version": "2.2.1",
-      "content_scripts":[{
-        "matches": [
-            "https://www.google.com/calendar/*",
-            "https://calendar.google.com/calendar/*"
-        ],
-        "js": [ "chroma.min.js", "events.user.js" ],
-        "run_at": "document_end",
-        "all_frames": true
-    }],
-  "permissions": [
+  "content_scripts": [
+    {
+      "matches": [
+        "https://www.google.com/calendar/*",
+        "https://calendar.google.com/calendar/*"
+      ],
+      "js": [
+        "chroma.min.js",
+        "events.user.js"
+      ],
+      "run_at": "document_end",
+      "all_frames": true
+    }
+  ],
+  "host_permissions": [
     "https://www.google.com/calendar/*",
-    "https://calendar.google.com/*",
+    "https://calendar.google.com/*"
+  ],
+  "permissions": [
     "storage"
   ],
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
-  "browser_action": {
+  "action": {
     "default_title": "Toggle"
   },
   "icons": {
     "48": "icon.png"
-  },
-  "content_security_policy": "default-src 'self'",
-  "manifest_version": 2
+  }
 }


### PR DESCRIPTION
This is now required in Chrome, can't get away anymore with patting Chrome's head soothingly and saying "it's alright, Google, it'll be OK".